### PR TITLE
Model caching improvments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,13 @@ ADD src .
 
 # Cache Models
 COPY builder/cache_models.py cache_models.py
+# We importing some packages from deforum repo for model downloading
+ENV PYTHONPATH="${PYTHONPATH}:/deforum-stable-diffusion/src"
 RUN python cache_models.py
 RUN rm cache_models.py
+
+# Create symlink (deforum has hardcoded paths for diffusion_models_cache for simplicity all models are stored in models folder)
+RUN ln -s /deforum-stable-diffusion/models /deforum-stable-diffusion/diffusion_models_cache
 
 # Cleanup section (Worker Template)
 RUN apt-get autoremove -y && \

--- a/builder/cache_models.py
+++ b/builder/cache_models.py
@@ -1,7 +1,10 @@
 import sys
-
+import os
+import wget
+import zipfile
 from types import SimpleNamespace
 from helpers.model_load import load_model, get_model_output_paths
+from helpers.depth import DepthModel
 
 from transformers import T5Tokenizer, T5EncoderModel, CLIPTokenizer, CLIPTextModel
 
@@ -9,7 +12,7 @@ sys.path.insert(0, "src")
 
 
 def PathSetup():
-    models_path = "diffusion_models_cache"  # @param {type:"string"}
+    models_path = "/deforum-stable-diffusion/models"  # @param {type:"string"}
     configs_path = "configs"  # @param {type:"string"}
     output_path = "outputs"  # @param {type:"string"}
     mount_google_drive = True  # @param {type:"boolean"}
@@ -47,10 +50,67 @@ try:
 except Exception as err:
     print(err)
 
-
 CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
 CLIPTextModel.from_pretrained("openai/clip-vit-large-patch14")
 
-
 T5Tokenizer.from_pretrained("google/t5-v1_1-xl")
 T5EncoderModel.from_pretrained("google/t5-v1_1-xl")
+
+# Initialize DepthModel
+depth_model = DepthModel(root.map_location)
+
+# Load and cache the models
+depth_model.load_adabins(root.models_path)
+depth_model.load_midas(root.models_path)
+
+def cache_aesthetics_models(root):
+    model_name = {
+        "ViT-B/32": "sac_public_2022_06_29_vit_b_32_linear.pth",
+        "ViT-B/16": "sac_public_2022_06_29_vit_b_16_linear.pth",
+        "ViT-L/14": "sac_public_2022_06_29_vit_l_14_linear.pth",
+    }
+    
+    for clip_name, file_name in model_name.items():
+        if not os.path.exists(os.path.join(root.models_path, file_name)):
+            print("Downloading aesthetics model...")
+            wget.download(
+                f"https://github.com/crowsonkb/simulacra-aesthetic-models/raw/master/models/{file_name}", 
+                out=os.path.join(root.models_path, file_name)
+            )
+
+cache_aesthetics_models(root)
+
+def cache_timm_models():
+    model_url = "https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ap-9e82fae8.pth"
+    model_path = "/root/.cache/torch/hub/checkpoints/"
+    
+    # Create the path if it doesn't exist
+    os.makedirs(model_path, exist_ok=True)
+    
+    # Download the model file
+    if not os.path.exists(os.path.join(model_path, "tf_efficientnet_b5_ap-9e82fae8.pth")):
+        print("Downloading tf_efficientnet_b5_ap-9e82fae8.pth model...")
+        wget.download(model_url, out=model_path)
+
+def cache_gen_efficientnet():
+    repo_url = "https://github.com/rwightman/gen-efficientnet-pytorch/zipball/master"
+    repo_path = "/root/.cache/torch/hub/"
+    zip_path = os.path.join(repo_path, "rwightman_gen-efficientnet-pytorch_master.zip")
+    extract_path = os.path.join(repo_path, "rwightman_gen-efficientnet-pytorch_master")
+    
+    # Create the path if it doesn't exist
+    os.makedirs(extract_path, exist_ok=True)
+
+    # Download the repo zip file
+    if not os.path.exists(zip_path):
+        print("Downloading gen-efficientnet-pytorch source code...")
+        wget.download(repo_url, out=zip_path)
+
+    # Extract the zip file
+    if not os.path.exists(os.path.join(extract_path, "setup.py")):  # assuming setup.py as an indicator of the source code
+        print("Extracting gen-efficientnet-pytorch source code...")
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            zip_ref.extractall(extract_path)
+
+cache_timm_models()
+cache_gen_efficientnet()

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -38,3 +38,4 @@ torchsde==0.2.5
 ninja==1.11.1
 triton
 xformers
+wget


### PR DESCRIPTION
In order to maintain compatibility and remove the issue of hardcoded 'diffusion_models_cache' directory when running the Docker container, I have updated the Dockerfile to create a symlink from 'models' to 'diffusion_models_cache'. 

The changes made in this pull request are as follows:

1. In the Dockerfile, I have added a `RUN` command to create a symlink from 'models' to 'diffusion_models_cache'. This ensures that every time a Docker container is run, the symlink will already be there as it was created when the Docker image was built. This eliminates the need for making changes to the deforum source code.

2. Fixed PYTHONPATH env variable in Dockerfile to make sure the 'src' directory is properly included for importing Deforum packages.

3. We have updated the script 'cache_models.py' to store the downloaded model files in the 'models' directory instead of 'diffusion_models_cache'. This allows for a cleaner and more organized directory structure ( That includes dependency models and also diffusion ckpt models)
